### PR TITLE
handle TypeError

### DIFF
--- a/ckanext/hierarchy/plugin.py
+++ b/ckanext/hierarchy/plugin.py
@@ -83,7 +83,10 @@ class HierarchyDisplay(p.SingletonPlugin):
             return name_list
 
         query = search_params.get('q', None)
-        c.include_children_selected = False
+        try:
+            c.include_children_selected = False
+        except TypeError:
+            return search_params
 
         # fix the issues with multiple times repeated fields
         # remove the param from the fields


### PR DESCRIPTION
In certain scenarios, c may not be properly initialised, causing this traceback -
```
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]   File "/usr/lib/ckan/default/src/ckanext-hierarchy/ckanext/hierarchy/plugin.py", line 87, in before_search
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]     c.include_children_selected = False
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]   File "/usr/lib/ckan/default/lib/python2.7/site-packages/paste/registry.py", line 140, in __setattr__
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]     setattr(self._current_obj(), attr, value)
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]   File "/usr/lib/ckan/default/lib/python2.7/site-packages/paste/registry.py", line 197, in _current_obj
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50]     'thread' % self.____name__)
[Thu Aug 24 14:32:06 2017] [error] [client 130.216.159.50] TypeError: No object (name: tmpl_context or C) has been registered for this thread
```

Specifically, I ran into this issue when calling `toolkit.get_action('organization_list')(data_dict={
              'all_fields': True,
              'include_extras': True
            })` from a different, custom plugin