### PR TITLE
Fix solr query when current organization does not have children

### DIFF
--- a/ckanext/hierarchy/plugin.py
+++ b/ckanext/hierarchy/plugin.py
@@ -109,6 +109,9 @@ class HierarchyDisplay(p.SingletonPlugin):
                 if (field == 'include_children'):
                     if (value.upper() != "FALSE"):
                         c.include_children_selected = True
+                    #Remove "include_children" parameter if present in "q" field at search_param variable, to avoid erronous condition
+                    # when the current organization has no children
+                    search_params['q'] = re.sub('include_children: "(True|False)"', '', search_params['q'], flags=re.IGNORECASE)
                     continue
                 base_query += [item]
         if c.include_children_selected:


### PR DESCRIPTION
When flag **"include_children"** is active and the organization where currently searching has no children, then the **"q"** field in solr query ends malformed. In example

_q="owner_org:"8cea3b55-a5c8-4439-ab34-26b7b326c8d9" include_children: "True""_

The result for this query is empty because "include_children" isn't a valid field in solr.
To solve this issue, the "include_children" condition must be removed from the "q" field.

-----------
**FAILURE USE CASE:**
We have the following hierarchy of organizations:

```
GrandFather Organization (1 dataset)
    |____ Father Organization (5 datasets)
                   |_____ Child Organization (2 datasets)
```
only searches at "Child Organization" fails when "include_children" is set, returning that no dataset was found at "Child Organization" when there is two.