### PR TITLE
Fix include_children behaviour when is set to False

### DIFF
--- a/ckanext/hierarchy/plugin.py
+++ b/ckanext/hierarchy/plugin.py
@@ -107,7 +107,7 @@ class HierarchyDisplay(p.SingletonPlugin):
                     continue
                 # skip include children andset option value
                 if (field == 'include_children'):
-                    if (value.upper() != "FALSE"):
+                    if (value.upper() != '"FALSE"'):
                         c.include_children_selected = True
                     continue
                 base_query += [item]


### PR DESCRIPTION
Fix string comparison. When parsing parameters, the value of **"include_children"** parameter comes with double quotes. In example
```
'"False"' or '"True"'
```
As result, the comparison in 

https://github.com/datagovuk/ckanext-hierarchy/blob/72b6dfdd56cd775457c37352d6cb0bcb0aaea261/ckanext/hierarchy/plugin.py#L110-L111

results always `true` when the "include_children" is set, even when set to "False".